### PR TITLE
Must re-layout the subviews to avoid OS-assertion failures on iOS 7.1

### DIFF
--- a/Classes/CAPSPageMenu.swift
+++ b/Classes/CAPSPageMenu.swift
@@ -799,6 +799,15 @@ class CAPSPageMenu: UIViewController, UIScrollViewDelegate, UIGestureRecognizerD
                 menuScrollView.setContentOffset(offset, animated: false)
             }
         }
+        
+        // Hsoi 2015-02-05 - Running on iOS 7.1 complained: "'NSInternalInconsistencyException', reason: 'Auto Layout 
+        // still required after sending -viewDidLayoutSubviews to the view controller. ViewController's implementation 
+        // needs to send -layoutSubviews to the view to invoke auto layout.'"
+        //
+        // http://stackoverflow.com/questions/15490140/auto-layout-error
+        //
+        // Given the SO answer and caveats presented there, we'll call layoutIfNeeded() instead.
+        self.view.layoutIfNeeded()
     }
     
     


### PR DESCRIPTION
Encountered an NSInternalInconsistencyException when running under iOS 7.1 (yes, 7.1... not 8.1 as I typoed in the commit comment).

In searching for solutions, a StackOverflow posting came up on the topic, and given the discussion in there, applied a change which seems to make things happy. Appears to work fine under iOS 7.1 and iOS 8.x.

Note: I saw no formal declaration of a minimum supported OS version for PageMenu. The only place I saw any sort of minimum OS was in the podspec, but is that because PageMenu is only supported under iOS 8? or because the Swift support in CocoaPods ends up forcing a minimum of iOS 8? Wasn't sure. Either way tho, the app I'm working on still needs to support iOS 7 and it does seem PageMenu is working fine under iOS 7... at least once this fix is applied.