### PR TITLE
Always set the controllerScrollView.contentSize in viewDidLayoutSubviews()

### DIFF
--- a/Classes/CAPSPageMenu.swift
+++ b/Classes/CAPSPageMenu.swift
@@ -732,14 +732,14 @@ class CAPSPageMenu: UIViewController, UIScrollViewDelegate, UIGestureRecognizerD
     // MARK: - Orientation Change
     
     override func viewDidLayoutSubviews() {
+        // Configure controller scroll view content size
+        controllerScrollView.contentSize = CGSizeMake(self.view.frame.width * CGFloat(controllerArray.count), self.view.frame.height - menuHeight)
+
         var oldCurrentOrientationIsPortrait : Bool = currentOrientationIsPortrait
         currentOrientationIsPortrait = self.interfaceOrientation.isPortrait
         
         if (oldCurrentOrientationIsPortrait && UIDevice.currentDevice().orientation.isLandscape) || (!oldCurrentOrientationIsPortrait && UIDevice.currentDevice().orientation.isPortrait) {
             didLayoutSubviewsAfterRotation = true
-            
-            // Configure controller scroll view content size
-            controllerScrollView.contentSize = CGSizeMake(self.view.frame.width * CGFloat(controllerArray.count), self.view.frame.height - menuHeight)
             
             //Resize menu items if using as segmented control
             if useMenuLikeSegmentedControl {


### PR DESCRIPTION
Every time `viewDidLayoutSubviews()` is called, we must set the `controllerScrollView.contentSize`. This is most important the first time around because when `configureUserInterface()` is called the whole view structure may not be fully laid out as it will appear on screen. This ensures the scrollView is always set right.

In my case, we noticed when under iOS 8.1 (it didn't seem to reproduce under iOS 7.1) that we could swipe further... 5 ViewControllers, and we could swipe as if there were 6 or 7. It was noticed when you paged via swiping the content, as opposed to tapping the menu items. But even in tapping the menu items we might see artifacts, such as the last menu item doesn't scroll fully on screen.

Using the RevealApp I could see that at configuration time the `controllerScrollView.contentSize` width was being set to 3000... but ultimately the frame width should be 414 with 5 VC's (thus 2070). The 600 probably comes out of the storyboard which is using size classes. This is not surprising because at configuration time it's still xib/storyboard sizes, not (re)sized yet for the actual screen layout. So we just need to ensure once things are fully setup and the OS is ready to roll that we ensure the contentSize is set as it should be. In this case, just do it always when the layout happens, not just when orientation changes.