### PR TITLE
PageMenu delegate should be declared weak, as per convention.

### DIFF
--- a/Classes/CAPSPageMenu.swift
+++ b/Classes/CAPSPageMenu.swift
@@ -113,7 +113,7 @@ public class CAPSPageMenu: UIViewController, UIScrollViewDelegate, UIGestureReco
     
     var pagesAddedDictionary : [Int : Int] = [:]
     
-    public var delegate : CAPSPageMenuDelegate?
+    public weak var delegate : CAPSPageMenuDelegate?
     
     var tapTimer : NSTimer?
     


### PR DESCRIPTION
Discovered this because my main ViewController that had the PageMenu as a child ViewController was holding onto the PageMenu and was also the PageMenu's delegate. Noticed my main ViewController wasn't being deinit()'d... and this was why.