### PR TITLE
fix for San Fransisco Font coming with iOS9

### DIFF
--- a/Classes/CAPSPageMenu.swift
+++ b/Classes/CAPSPageMenu.swift
@@ -113,7 +113,7 @@ public class CAPSPageMenu: UIViewController, UIScrollViewDelegate, UIGestureReco
     public var bottomMenuHairlineColor : UIColor = UIColor.whiteColor()
     public var menuItemSeparatorColor : UIColor = UIColor.lightGrayColor()
     
-    public var menuItemFont : UIFont = UIFont(name: "HelveticaNeue", size: 15.0)!
+    public var menuItemFont : UIFont = UIFont.systemFontOfSize(15.0)!
     public var menuItemSeparatorPercentageHeight : CGFloat = 0.2
     public var menuItemSeparatorWidth : CGFloat = 0.5
     public var menuItemSeparatorRoundEdges : Bool = false

--- a/Obj-C Classes/CAPSPageMenu.m
+++ b/Obj-C Classes/CAPSPageMenu.m
@@ -196,7 +196,7 @@ NSString * const CAPSPageMenuOptionHideTopMenuBar                       = @"hide
     _bottomMenuHairlineColor      = [UIColor whiteColor];
     _menuItemSeparatorColor       = [UIColor lightGrayColor];
     
-    _menuItemFont = [UIFont fontWithName:@"HelveticaNeue" size:15.0];
+    _menuItemFont = [UIFont systemFontOfSize:15.0];
     _menuItemSeparatorPercentageHeight = 0.2;
     _menuItemSeparatorWidth            = 0.5;
     _menuItemSeparatorRoundEdges       = NO;


### PR DESCRIPTION
Should use systemFontOfSize, instead of specifying the name of the Font