### PR TITLE
Now is possible use images on menuItems.

### DIFF
--- a/Classes/CAPSPageMenu.swift
+++ b/Classes/CAPSPageMenu.swift
@@ -26,7 +26,7 @@ import UIKit
     optional func didMoveToPage(controller: UIViewController, index: Int)
 }
 
-public class PageViewController : BaseViewController {
+public class PageViewController : UIViewController {
     var titleImage : UIImage? ;
     var selectedTitleImage : UIImage? ;
     


### PR DESCRIPTION
- I was added the capability to use images as tabItems.
  You only need use:

`controller.titleImage = UIImage(named: "name image")`
`let parameters: [CAPSPageMenuOption] = [`
`.MenuHeight(60),`
`.MenuItemWidth (screenwidth/3),`
`.MenuTitleImageWidth(80),`
`.MenuTitleImageHeight(35),`
`.ScrollMenuBackgroundColor(FOXConstants.CHANNELSTAB_BG_INACTIVE),`
`.SelectedMenuItemBackgroundColor(UIColor.whiteColor()),`
`.SelectionIndicatorColor(FOXConstants.COLOR_SKYBLUE) ,`
`.MenuMargin(0)`
`]`

`let pageMenu = CAPSPageMenu(viewControllers: controllerArray, frame: CGRectMake(0.0, 0.0, self.view.frame.width, self.view.frame.height), pageMenuOptions: parameters)`
