### PR TITLE
fix issue #71 :: viewWillAppear is loaded before viewDidLoad

### DIFF
--- a/Classes/CAPSPageMenu.swift
+++ b/Classes/CAPSPageMenu.swift
@@ -211,8 +211,6 @@ extension CAPSPageMenu {
         
         let newVC = controllerArray[index]
         
-        newVC.willMove(toParentViewController: self)
-        
         newVC.view.frame = CGRect(x: self.view.frame.width * CGFloat(index), y: configuration.menuHeight, width: self.view.frame.width, height: self.view.frame.height - configuration.menuHeight)
         
         self.addChildViewController(newVC)


### PR DESCRIPTION
the reason that viewWillAppear is loaded before viewDidLoad is PageMenu call willMove(toParent:) before access the view controller's view, and according to apple's document (https://developer.apple.com/documentation/uikit/uiviewcontroller/1621381-willmove), they say: 
"When your custom container calls the addChild(_:) method, it automatically calls the willMove(toParent:) method of the view controller to be added as a child before adding it."
so we can remove the willMove(toParent:) and fix this problem.
